### PR TITLE
Add border fix for legacy Mutter environments

### DIFF
--- a/themes/Nightfox-Dusk-B-LB/gtk-3.0/gtk-dark.css
+++ b/themes/Nightfox-Dusk-B-LB/gtk-3.0/gtk-dark.css
@@ -45090,9 +45090,15 @@ decoration:backdrop {
 }
 
 .ssd decoration {
-  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16), 0 0 0 2px #cdcbe0;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16),
+    0 0 0 2px #d84f76;
   border: none;
   border-radius: 12px 12px 0 0;
+}
+
+.ssd decoration:backdrop {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16), 
+    0 0 0 2px #4b4673;
 }
 
 .csd.popup decoration {

--- a/themes/Nightfox-Dusk-B-LB/gtk-3.0/gtk.css
+++ b/themes/Nightfox-Dusk-B-LB/gtk-3.0/gtk.css
@@ -45088,9 +45088,15 @@ decoration:backdrop {
 }
 
 .ssd decoration {
-  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16), 0 0 0 2px #cdcbe0;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16),
+    0 0 0 2px #d84f76;
   border: none;
   border-radius: 12px 12px 0 0;
+}
+
+.ssd decoration:backdrop {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16), 
+    0 0 0 2px #4b4673;
 }
 
 .csd.popup decoration {

--- a/themes/Nightfox-Dusk-B/gtk-3.0/gtk-dark.css
+++ b/themes/Nightfox-Dusk-B/gtk-3.0/gtk-dark.css
@@ -45090,9 +45090,15 @@ decoration:backdrop {
 }
 
 .ssd decoration {
-  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16), 0 0 0 2px #cdcbe0;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16),
+    0 0 0 2px #d84f76;
   border: none;
   border-radius: 12px 12px 0 0;
+}
+
+.ssd decoration:backdrop {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16), 
+    0 0 0 2px #4b4673;
 }
 
 .csd.popup decoration {

--- a/themes/Nightfox-Dusk-B/gtk-3.0/gtk.css
+++ b/themes/Nightfox-Dusk-B/gtk-3.0/gtk.css
@@ -45088,9 +45088,15 @@ decoration:backdrop {
 }
 
 .ssd decoration {
-  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16), 0 0 0 2px #cdcbe0;
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16),
+    0 0 0 2px #d84f76;
   border: none;
   border-radius: 12px 12px 0 0;
+}
+
+.ssd decoration:backdrop {
+  box-shadow: 0 3px 3px rgba(0, 0, 0, 0.16), 
+    0 0 0 2px #4b4673;
 }
 
 .csd.popup decoration {


### PR DESCRIPTION
Implemented rendering fix for Mutter-based desktop environments (like Cinnamon 5.4.12)

![Screenshot from 2022-11-19 16-32-46](https://user-images.githubusercontent.com/6565187/202872376-80ff28c6-4a11-462d-9c02-79ddb7d2bec3.png)

Resolves https://github.com/Fausto-Korpsvart/Nightfox-GTK-Theme/issues/1

## Explanation

The `.ssd` class represents _Server Side Decorating_, a concept that seems particular to certain Mutter-based environments. Instead of applying to the `.csd` _(Client Side Decoration)_ class - it seems to only apply to the server side one when rendering in Cinnamon 5.4.12.

Here's where I sourced my info (could literally only find this line describing the issue): https://docs.gtk.org/gtk3/class.Window.html#css-nodes